### PR TITLE
feat: migrate to ovos-spec-tools

### DIFF
--- a/benchmark/accuracy.py
+++ b/benchmark/accuracy.py
@@ -64,15 +64,19 @@ def run():
     for utt, expected, predicted, conf in results:
         if expected is not None:
             if predicted == expected:
-                tp += 1; per_tp[expected] += 1
+                tp += 1
+                per_tp[expected] += 1
             else:
-                fn += 1; per_fn[expected] += 1
+                fn += 1
+                per_fn[expected] += 1
                 if predicted is not None:
-                    fp += 1; per_fp[predicted] += 1
+                    fp += 1
+                    per_fp[predicted] += 1
                 wrong.append((utt, expected, predicted, conf))
         else:
             if predicted is not None:
-                fp += 1; per_fp[predicted] += 1
+                fp += 1
+                per_fp[predicted] += 1
                 wrong.append((utt, expected, predicted, conf))
             else:
                 tn += 1
@@ -85,7 +89,7 @@ def run():
 
     lat_s = sorted(latencies)
     print(f"\n{'='*60}")
-    print(f"  Accuracy benchmark  —  palavreado")
+    print("  Accuracy benchmark  —  palavreado")
     print(f"{'='*60}")
     print(f"  Total cases     : {total}  ({match_n} match, {nomatch_n} no-match)")
     print(f"  Correct         : {tp+tn}/{total}  ({accuracy:.1%})")
@@ -102,7 +106,9 @@ def run():
     print(f"\n  {'Intent':<24} {'TP':>4} {'FN':>4} {'Recall':>8}  {'FP':>4}")
     print(f"  {'-'*50}")
     for name in sorted(INTENTS):
-        tp_ = per_tp[name]; fn_ = per_fn[name]; fp_ = per_fp[name]
+        tp_ = per_tp[name]
+        fn_ = per_fn[name]
+        fp_ = per_fp[name]
         rec = tp_ / (tp_ + fn_) if (tp_ + fn_) else 0.0
         flag = " !" if rec < 1.0 or fp_ > 0 else ""
         print(f"  {name:<24} {tp_:>4} {fn_:>4} {rec:>7.0%}  {fp_:>4}{flag}")

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -35,20 +35,26 @@ def compute_metrics(results, cases):
     match_n   = sum(1 for _, e in cases if e is not None)
     nomatch_n = total - match_n
     tp = fp = fn = tn = 0
-    per_tp = defaultdict(int); per_fn = defaultdict(int); per_fp = defaultdict(int)
+    per_tp = defaultdict(int)
+    per_fn = defaultdict(int)
+    per_fp = defaultdict(int)
     wrong = []
     for (predicted, conf), (utt, expected) in zip(results, cases):
         if expected is not None:
             if predicted == expected:
-                tp += 1; per_tp[expected] += 1
+                tp += 1
+                per_tp[expected] += 1
             else:
-                fn += 1; per_fn[expected] += 1
+                fn += 1
+                per_fn[expected] += 1
                 if predicted is not None:
-                    fp += 1; per_fp[predicted] += 1
+                    fp += 1
+                    per_fp[predicted] += 1
                 wrong.append((utt, expected, predicted, conf))
         else:
             if predicted is not None:
-                fp += 1; per_fp[predicted] += 1
+                fp += 1
+                per_fp[predicted] += 1
                 wrong.append((utt, expected, predicted, conf))
             else:
                 tn += 1
@@ -80,7 +86,7 @@ def print_report(label, m, latencies):
 
     issues = sorted(set(m["per_fn"]) | set(m["per_fp"]))
     if issues:
-        print(f"\n  Per-intent (issues only):")
+        print("\n  Per-intent (issues only):")
         for name in sorted(INTENTS):
             fn = m["per_fn"].get(name, 0)
             fp = m["per_fp"].get(name, 0)
@@ -182,7 +188,7 @@ def summary(rows):
         print(f"  {label:<32} {m['accuracy']:>5.1%} {m['precision']:>5.1%} "
               f"{m['recall']:>6.1%} {m['f1']:>5.3f}  {tn_frac:>8}  {m['fp']:>4}  {median_lat:>6.2f}ms")
     print(f"{'─'*90}")
-    print(f"  TN/NM = true negatives / total no-match cases (correctly returned nothing)")
+    print("  TN/NM = true negatives / total no-match cases (correctly returned nothing)")
 
 
 # ── main ───────────────────────────────────────────────────────────────────
@@ -193,7 +199,7 @@ if __name__ == "__main__":
     print(f"\nDataset : {len(cases)} cases  ({match_n} match, {len(cases)-match_n} no-match)")
     print(f"Intents : {len(INTENTS)}")
     print(f"Vocab   : {sum(len(v) for v in VOCAB.values())} keyword samples across {len(VOCAB)} entity types")
-    print(f"Note    : keyword parsers require the vocabulary word to appear in the utterance.")
+    print("Note    : keyword parsers require the vocabulary word to appear in the utterance.")
 
     rows = []
 

--- a/palavreado/bracket_expansion.py
+++ b/palavreado/bracket_expansion.py
@@ -9,53 +9,36 @@ Also provides :func:`normalize_utterance`, :func:`normalize_example`, and
 :func:`lemmatize` so that training data and queries match robustly across
 apostrophe and plural variants.
 """
-import itertools
 import re
+import warnings
 from typing import List
 
+from ovos_spec_tools import expand
+from ovos_utils.log import deprecated
 
+from palavreado.version import VERSION_MAJOR
+
+_REMOVAL = f"{VERSION_MAJOR + 1}.0.0"
+
+
+@deprecated(
+    "palavreado.bracket_expansion.expand_parentheses is deprecated; "
+    "use ovos_spec_tools.expand instead.",
+    _REMOVAL,
+)
 def expand_parentheses(sent: str) -> List[str]:
-    """Expand a template string with ``(a|b)`` alternatives and ``[optional]`` syntax
-    into all possible combinations.
+    """Deprecated shim — delegates to :func:`ovos_spec_tools.expand`.
 
-    Args:
-        sent: A pattern string containing ``(a|b)`` alternations and/or
-            ``[optional]`` sections.
-
-    Returns:
-        A flat list of all expanded sentence strings, sorted for determinism.
-
-    Examples:
-        >>> expand_parentheses("Will it (rain|pour) [today]?")
-        ["Will it pour?", "Will it pour today?", "Will it rain?", "Will it rain today?"]
+    Kept for backwards compatibility. New code should import ``expand``
+    from ``ovos_spec_tools`` directly.
     """
-    def _expand_optional(text):
-        return re.sub(r"\[([^\[\]]+)\]", lambda m: f"({m.group(1)}|)", text)
-
-    def _expand_alternatives(text):
-        parts = []
-        for segment in re.split(r"(\([^\(\)]+\))", text):
-            if segment.startswith("(") and segment.endswith(")"):
-                parts.append(segment[1:-1].split("|"))
-            else:
-                parts.append([segment])
-        return itertools.product(*parts)
-
-    def _fully_expand(texts):
-        result = set(texts)
-        while True:
-            expanded = set()
-            for text in result:
-                for combo in _expand_alternatives(text):
-                    # collapse internal whitespace so the empty branch of
-                    # [optional] doesn't leave a double space
-                    expanded.add(re.sub(r' +', ' ', "".join(combo)).strip())
-            if expanded == result:
-                break
-            result = expanded
-        return sorted(result)
-
-    return _fully_expand([_expand_optional(sent)])
+    warnings.warn(
+        "palavreado.bracket_expansion.expand_parentheses is deprecated; "
+        "use ovos_spec_tools.expand instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return sorted(expand(sent))
 
 
 def clean_braces(example: str) -> str:

--- a/palavreado/builder.py
+++ b/palavreado/builder.py
@@ -8,7 +8,7 @@ Builder helpers for constructing palavreado intents programmatically.
 import simplematch as sm
 from typing import List, Union
 
-from palavreado.bracket_expansion import expand_parentheses
+from ovos_spec_tools import expand as _spec_expand
 
 
 def pattern2regex(pattern: str, case_sensitive: bool = False) -> str:
@@ -41,7 +41,14 @@ def expand_samples(samples: Union[str, List[str]]) -> List[str]:
         samples = [samples]
     expanded = []
     for line in samples:
-        expanded += expand_parentheses(line)
+        # spec-tools expand enforces OVOS-INTENT-1 slot-name rules; palavreado
+        # also accepts simplematch typed slots like {n:int} via autoregex.
+        # Skip expansion when there are no bracket alternatives to expand.
+        if "(" not in line and "[" not in line:
+            expanded.append(line)
+        else:
+            # sorted for determinism — matches legacy expand_parentheses behaviour
+            expanded += sorted(_spec_expand(line))
     return expanded
 
 

--- a/palavreado/opm.py
+++ b/palavreado/opm.py
@@ -3,16 +3,15 @@
 import time
 from typing import Dict, List, Optional, Union
 
-from langcodes import closest_match
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager, Session
 from ovos_bus_client.util import get_message_lang
 from ovos_config.config import Configuration
 from ovos_plugin_manager.templates.pipeline import ConfidenceMatcherPipeline, IntentHandlerMatch
+from ovos_spec_tools import closest_lang, standardize_lang
 from ovos_utils import flatten_list
 from ovos_utils.fakebus import FakeBus
-from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.log import LOG
 from ovos_spec_tools import SpecMessage, gate_satisfied, is_live
 from ovos_workshop.intents import open_intent_envelope
@@ -35,11 +34,11 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
         config = config or core_config.get("intents", {}).get("palavreado", {}) or core_config.get("palavreado", {})
         super().__init__(bus=bus, config=config)
 
-        self.lang = standardize_lang_tag(core_config.get("lang", "en-US"))
+        self.lang = standardize_lang(core_config.get("lang", "en-US"))
         langs = core_config.get("secondary_langs") or []
         if self.lang not in langs:
             langs.append(self.lang)
-        langs = [standardize_lang_tag(lang) for lang in langs]
+        langs = [standardize_lang(lang) for lang in langs]
 
         self.conf_high = self.config.get("conf_high") or 0.65
         self.conf_med = self.config.get("conf_med") or 0.45
@@ -109,8 +108,7 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
         - ``regex``:        (optional) raw regex string instead of a keyword
         - ``lang``:         BCP-47 language tag
         """
-        lang = standardize_lang_tag(get_message_lang(message))
-        lang = self._resolve_lang(lang)
+        lang = self._resolve_lang(get_message_lang(message))
         if lang is None:
             return
 
@@ -142,8 +140,7 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
         accumulated vocab store.
         """
         intent = open_intent_envelope(message)
-        lang = standardize_lang_tag(get_message_lang(message))
-        lang = self._resolve_lang(lang)
+        lang = self._resolve_lang(get_message_lang(message))
         if lang is None:
             return
 
@@ -683,9 +680,7 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
     def _resolve_lang(self, lang: str) -> Optional[str]:
         if not self.containers:
             return None
-        lang = standardize_lang_tag(lang)
-        closest, score = closest_match(lang, list(self.containers.keys()))
-        return closest if score < 10 else None
+        return closest_lang(standardize_lang(lang), list(self.containers.keys()))
 
     def shutdown(self) -> None:
         self.bus.remove("register_vocab", self.handle_register_vocab)

--- a/palavreado/opm.py
+++ b/palavreado/opm.py
@@ -251,7 +251,7 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
         data = message.data
         skill_id = data.get("skill_id") or message.context.get("skill_id", "")
         intent_name = data.get("intent_name", "")
-        lang = standardize_lang_tag(data.get("lang") or get_message_lang(message))
+        lang = standardize_lang(data.get("lang") or get_message_lang(message))
         topic = str(SpecMessage.INTENT_REGISTER_KEYWORD)
 
         def _reject(reason: str) -> None:
@@ -371,7 +371,7 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
         data = message.data
         skill_id = data.get("skill_id") or message.context.get("skill_id", "")
         entity_name = data.get("entity_name", "")
-        lang = standardize_lang_tag(data.get("lang") or get_message_lang(message))
+        lang = standardize_lang(data.get("lang") or get_message_lang(message))
         topic = str(SpecMessage.ENTITY_REGISTER)
 
         samples = data.get("samples") or []
@@ -425,7 +425,6 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
     def handle_entity_deregister(self, message: Message) -> None:
         """Remove one entity value-set (OVOS-INTENT-4 §8.3)."""
         data = message.data
-        skill_id = data.get("skill_id") or message.context.get("skill_id", "")
         entity_name = data.get("entity_name", "")
         if not entity_name:
             return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 requires-python = ">=3.10"
-dependencies = ["simplematch", "quebra_frases"]
+dependencies = ["simplematch", "quebra_frases", "ovos-spec-tools>=1.0.0a1,<2.0.0"]
 
 [project.optional-dependencies]
 ovos = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 simplematch
 quebra_frases
+ovos-spec-tools


### PR DESCRIPTION
Migrates palavreado onto [ovos-spec-tools](https://github.com/OpenVoiceOS/ovos-spec-tools) primitives.

## Replacements

| Local symbol | Replaced by |
|---|---|
| `palavreado.bracket_expansion.expand_parentheses` | `ovos_spec_tools.expand` (kept as deprecation shim) |
| `palavreado.builder.expand_samples` (internal) | `ovos_spec_tools.expand` for bracket templates; passes simplematch typed-slot templates through unchanged for the autoregex path |
| `ovos_utils.lang.standardize_lang_tag` | `ovos_spec_tools.standardize_lang` |
| `langcodes.closest_match` + `score < 10` boilerplate | `ovos_spec_tools.closest_lang` |

## Language policy

Full normalized BCP-47 tags are used everywhere. No `macro=True` flag — engines reconcile at match time via `closest_lang`, never by macro-stripping at registration.

## Backwards compatibility

`palavreado.bracket_expansion.expand_parentheses` remains importable as a deprecation shim:
- emits `DeprecationWarning`
- decorated with `@deprecated` from `ovos_utils.log` (removal in next major version)
- delegates to `ovos_spec_tools.expand` (sorted for determinism, matching legacy output order)

## Dependencies

- `requirements.txt`: added `ovos-spec-tools`
- `pyproject.toml`: added `ovos-spec-tools` to `dependencies`

## Tests

All 103 tests pass (`python -m pytest test/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)