### PR TITLE
feat: consume OVOS-INTENT-4 keyword registration (alongside legacy)

### DIFF
--- a/.github/workflows/ovoscope.yml
+++ b/.github/workflows/ovoscope.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'palavreado/**'
       - 'test/test_ovoscope_e2e.py'
+      - 'test/end2end/**'
       - '.github/workflows/ovoscope.yml'
   workflow_dispatch:
 
@@ -14,7 +15,7 @@ jobs:
     uses: OpenVoiceOS/gh-automations/.github/workflows/ovoscope.yml@dev
     with:
       install_extras: "test"
-      test_path: "test/test_ovoscope_e2e.py"
+      test_path: "test/test_ovoscope_e2e.py test/end2end/"
       require_palavreado: true
       # Validate against the unreleased ovoscope + palavreado dev branches
       # (needed for the E2EPipelineHarness used by the refactored e2e tests).

--- a/palavreado/opm.py
+++ b/palavreado/opm.py
@@ -580,9 +580,9 @@ def _calc_palavreado_intent(utt: str,
         result = container.calc_intent(utt)
         if not result.get("name"):
             return None
-        if result["name"] in sess.blacklisted_intents:
+        if result["name"] in (sess.blacklisted_intents or []):
             return None
-        if result["name"].split(":")[0] in sess.blacklisted_skills:
+        if result["name"].split(":")[0] in (sess.blacklisted_skills or []):
             return None
         return result
     except Exception as e:

--- a/palavreado/opm.py
+++ b/palavreado/opm.py
@@ -13,6 +13,7 @@ from ovos_utils import flatten_list
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.log import LOG
+from ovos_spec_tools import SpecMessage
 from ovos_workshop.intents import open_intent_envelope
 
 from palavreado import IntentContainer
@@ -58,10 +59,24 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
         self.registered_vocab: List[dict] = []
         self._registered_intents: List[dict] = []  # raw intent dicts for manifest
 
+        # disabled intents (OVOS-INTENT-4 §8.5) — excluded from matching but kept
+        self._disabled_intents: set = set()
+
+        # ── legacy registration topics (back-compat) ──────────────────────────
         self.bus.on("register_vocab", self.handle_register_vocab)
         self.bus.on("register_intent", self.handle_register_intent)
         self.bus.on("detach_intent", self.handle_detach_intent)
         self.bus.on("detach_skill", self.handle_detach_skill)
+
+        # ── OVOS-INTENT-4 registration topics ─────────────────────────────────
+        # palavreado is keyword/slot based → primary topic is register.keyword.
+        self.bus.on(str(SpecMessage.INTENT_REGISTER_KEYWORD), self.handle_register_keyword_intent)
+        self.bus.on(str(SpecMessage.ENTITY_REGISTER), self.handle_register_entity)
+        self.bus.on(str(SpecMessage.INTENT_DEREGISTER), self.handle_intent_deregister)
+        self.bus.on(str(SpecMessage.ENTITY_DEREGISTER), self.handle_entity_deregister)
+        self.bus.on(str(SpecMessage.SKILL_DEREGISTER), self.handle_skill_deregister)
+        self.bus.on(str(SpecMessage.INTENT_ENABLE), self.handle_intent_enable)
+        self.bus.on(str(SpecMessage.INTENT_DISABLE), self.handle_intent_disable)
 
         self.bus.on("intent.service.palavreado.get", self.handle_get_palavreado)
         self.bus.on("intent.service.palavreado.manifest.get", self.handle_palavreado_manifest)
@@ -150,6 +165,254 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
             pass
 
         self._registered_intents.append(intent.__dict__)
+
+    # ── OVOS-INTENT-4 handlers ────────────────────────────────────────────────
+
+    @staticmethod
+    def _spec_intent_name(skill_id: str, intent_name: str) -> str:
+        """Build palavreado's internal intent name from INTENT-4 identity.
+
+        palavreado names intents ``<skill_id>:<intent_name>`` so the
+        ``skill_id`` can be recovered with ``name.split(":")[0]`` (the same
+        convention the legacy adapt envelope uses).
+        """
+        if intent_name.startswith(f"{skill_id}:"):
+            return intent_name
+        return f"{skill_id}:{intent_name}"
+
+    @staticmethod
+    def _descriptor_samples(descriptor: dict) -> List[str]:
+        """Extract the inline ``samples`` of a §5.1 vocabulary descriptor."""
+        if not isinstance(descriptor, dict):
+            return []
+        samples = descriptor.get("samples") or []
+        if isinstance(samples, str):
+            samples = [samples]
+        return [s for s in samples if isinstance(s, str) and s.strip()]
+
+    def handle_register_keyword_intent(self, message: Message) -> None:
+        """Register a keyword intent from an OVOS-INTENT-4 §5 payload.
+
+        Maps the spec's ``required`` / ``optional`` / ``one_of`` / ``excluded``
+        vocabulary descriptors (with inline ``samples``) onto palavreado's
+        keyword/slot model:
+
+        - ``required`` descriptor  → :meth:`IntentCreator.require`
+        - ``optional`` descriptor  → :meth:`IntentCreator.optionally`
+        - ``one_of`` group member  → :meth:`IntentCreator.optionally`
+          (palavreado has no native "at least one of" slot; each group member
+          becomes an optional slot, mirroring the legacy ``at_least_one``
+          handling in :meth:`handle_register_intent`)
+        - ``excluded`` descriptor  → :meth:`IntentContainer.exclude_keywords`
+          (the §5.4 suppression mechanism)
+
+        Malformed payloads (§5.3) are rejected and logged at WARN; they are
+        the producer's only debugging signal since the bus is fire-and-forget.
+        """
+        data = message.data
+        skill_id = data.get("skill_id") or message.context.get("skill_id", "")
+        intent_name = data.get("intent_name", "")
+        lang = standardize_lang_tag(data.get("lang") or get_message_lang(message))
+        topic = str(SpecMessage.INTENT_REGISTER_KEYWORD)
+
+        def _reject(reason: str) -> None:
+            LOG.warning(f"rejected registration topic={topic} "
+                        f"skill_id={skill_id!r} intent_name={intent_name!r} "
+                        f"lang={lang!r}: {reason}")
+
+        if not skill_id or not intent_name:
+            _reject("missing skill_id or intent_name")
+            return
+
+        # §5.3 / §5.2: all four role keys MUST be present
+        for key in ("required", "optional", "one_of", "excluded"):
+            if key not in data:
+                _reject(f"missing required key '{key}'")
+                return
+
+        resolved_lang = self._resolve_lang(lang)
+        if resolved_lang is None:
+            _reject(f"no container for lang {lang!r}")
+            return
+
+        required = data.get("required") or []
+        optional = data.get("optional") or []
+        one_of = data.get("one_of") or []
+        excluded = data.get("excluded") or []
+
+        # §5.3: required + one_of MUST NOT both be empty
+        if not required and not one_of:
+            _reject("required and one_of are both empty")
+            return
+
+        # §5.3: every descriptor MUST carry a non-empty samples list that
+        # expands to at least one non-empty sample.
+        flat_descriptors = list(required) + list(optional) + list(excluded)
+        for group in one_of:
+            flat_descriptors += list(group or [])
+        # §5.3: a vocabulary name MUST NOT appear under more than one role.
+        seen_names: Dict[str, str] = {}
+        for descriptor in flat_descriptors:
+            if not isinstance(descriptor, dict) or not descriptor.get("name"):
+                _reject("vocabulary descriptor missing 'name'")
+                return
+            if not self._descriptor_samples(descriptor):
+                _reject(f"vocabulary {descriptor.get('name')!r} has no non-empty samples")
+                return
+        for role, descriptors in (("required", required), ("optional", optional)):
+            for descriptor in descriptors:
+                name = descriptor["name"]
+                if name in seen_names:
+                    _reject(f"vocabulary {name!r} appears under multiple roles")
+                    return
+                seen_names[name] = role
+        for group in one_of:
+            for descriptor in (group or []):
+                name = descriptor["name"]
+                if name in seen_names and seen_names[name] != "one_of":
+                    _reject(f"vocabulary {name!r} appears under multiple roles")
+                    return
+                seen_names[name] = "one_of"
+
+        internal_name = self._spec_intent_name(skill_id, intent_name)
+
+        # §8.1: re-registration replaces the existing intent (per language)
+        container = self.containers[resolved_lang]
+        container.remove_intent(internal_name)
+        self._registered_intents = [i for i in self._registered_intents
+                                    if i.get("name") != internal_name]
+
+        creator = IntentCreator(internal_name)
+        for descriptor in required:
+            creator.require(descriptor["name"], self._descriptor_samples(descriptor))
+        for descriptor in optional:
+            creator.optionally(descriptor["name"], self._descriptor_samples(descriptor))
+        for group in one_of:
+            for descriptor in (group or []):
+                creator.optionally(descriptor["name"], self._descriptor_samples(descriptor))
+
+        container.add_intent(creator)
+
+        # §5.4: excluded role → keyword suppression
+        excluded_samples: List[str] = []
+        for descriptor in excluded:
+            excluded_samples += self._descriptor_samples(descriptor)
+        if excluded_samples:
+            container.exclude_keywords(internal_name, excluded_samples)
+
+        self._registered_intents.append({"name": internal_name,
+                                         "skill_id": skill_id,
+                                         "lang": resolved_lang,
+                                         "method": "keyword"})
+        LOG.debug(f"registered keyword intent {internal_name} ({resolved_lang})")
+
+    def handle_register_entity(self, message: Message) -> None:
+        """Register an OVOS-INTENT-4 §7 entity value-set hint.
+
+        Stores the entity's inline ``samples`` in the per-lang vocab store
+        keyed by ``entity_name`` so keyword intents that reference the slot by
+        name can pick them up (a value-set hint, never a precondition; §7).
+        Rejects payloads with empty ``samples`` (§7.2).
+        """
+        data = message.data
+        skill_id = data.get("skill_id") or message.context.get("skill_id", "")
+        entity_name = data.get("entity_name", "")
+        lang = standardize_lang_tag(data.get("lang") or get_message_lang(message))
+        topic = str(SpecMessage.ENTITY_REGISTER)
+
+        samples = data.get("samples") or []
+        if isinstance(samples, str):
+            samples = [samples]
+        samples = [s for s in samples if isinstance(s, str) and s.strip()]
+
+        if not entity_name or not samples:
+            LOG.warning(f"rejected registration topic={topic} "
+                        f"skill_id={skill_id!r} entity_name={entity_name!r} "
+                        f"lang={lang!r}: missing entity_name or non-empty samples")
+            return
+
+        resolved_lang = self._resolve_lang(lang)
+        if resolved_lang is None:
+            LOG.warning(f"rejected registration topic={topic} "
+                        f"skill_id={skill_id!r} entity_name={entity_name!r} "
+                        f"lang={lang!r}: no container for lang")
+            return
+
+        # §8.1: replacement keyed on (skill_id, entity_name, lang)
+        store = self._vocab[resolved_lang].setdefault(entity_name, [])
+        for sample in samples:
+            if sample not in store:
+                store.append(sample)
+        self.registered_vocab.append({"entity_type": entity_name,
+                                      "entity_value": samples,
+                                      "skill_id": skill_id,
+                                      "lang": resolved_lang})
+
+    def handle_intent_deregister(self, message: Message) -> None:
+        """Remove one intent (OVOS-INTENT-4 §8.2).
+
+        Targets the ``(skill_id, intent_name)`` identity; when ``lang`` is
+        omitted, removes the intent for every registered language.
+        """
+        data = message.data
+        skill_id = data.get("skill_id") or message.context.get("skill_id", "")
+        intent_name = data.get("intent_name", "")
+        if not skill_id or not intent_name:
+            return
+        internal_name = self._spec_intent_name(skill_id, intent_name)
+        self._disabled_intents.discard(internal_name)
+        self._registered_intents = [i for i in self._registered_intents
+                                    if i.get("name") != internal_name]
+        for container in self.containers.values():
+            container.remove_intent(internal_name)
+
+    def handle_entity_deregister(self, message: Message) -> None:
+        """Remove one entity value-set (OVOS-INTENT-4 §8.3)."""
+        data = message.data
+        skill_id = data.get("skill_id") or message.context.get("skill_id", "")
+        entity_name = data.get("entity_name", "")
+        if not entity_name:
+            return
+        for vocab in self._vocab.values():
+            vocab.pop(entity_name, None)
+        self.registered_vocab = [v for v in self.registered_vocab
+                                 if v.get("entity_type") != entity_name]
+
+    def handle_skill_deregister(self, message: Message) -> None:
+        """Remove every intent and entity owned by a skill (OVOS-INTENT-4 §8.4)."""
+        skill_id = message.data.get("skill_id") or message.context.get("skill_id", "")
+        if not skill_id:
+            return
+        prefix = f"{skill_id}:"
+        self._disabled_intents = {n for n in self._disabled_intents
+                                  if not n.startswith(prefix)}
+        self._registered_intents = [i for i in self._registered_intents
+                                    if i.get("skill_id") != skill_id
+                                    and not i.get("name", "").startswith(prefix)]
+        self.registered_vocab = [v for v in self.registered_vocab
+                                 if v.get("skill_id") != skill_id]
+        for container in self.containers.values():
+            for intent_name in list(container.intent_names):
+                if intent_name.startswith(prefix):
+                    container.remove_intent(intent_name)
+
+    def handle_intent_disable(self, message: Message) -> None:
+        """Suppress an intent without removing it (OVOS-INTENT-4 §8.5)."""
+        data = message.data
+        skill_id = data.get("skill_id") or message.context.get("skill_id", "")
+        intent_name = data.get("intent_name", "")
+        if not skill_id or not intent_name:
+            return
+        self._disabled_intents.add(self._spec_intent_name(skill_id, intent_name))
+
+    def handle_intent_enable(self, message: Message) -> None:
+        """Re-arm a previously disabled intent (OVOS-INTENT-4 §8.5)."""
+        data = message.data
+        skill_id = data.get("skill_id") or message.context.get("skill_id", "")
+        intent_name = data.get("intent_name", "")
+        if not skill_id or not intent_name:
+            return
+        self._disabled_intents.discard(self._spec_intent_name(skill_id, intent_name))
 
     def handle_detach_intent(self, message: Message) -> None:
         """Remove a single intent by name."""
@@ -257,6 +520,8 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
 
         for utt in utts:
             result = _calc_palavreado_intent(utt, container, sess)
+            if result and result["name"] in self._disabled_intents:
+                continue  # OVOS-INTENT-4 §8.5: disabled intents are not candidates
             if result and result["conf"] > best_conf:
                 best_conf = result["conf"]
                 best = result
@@ -291,6 +556,13 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
         self.bus.remove("register_intent", self.handle_register_intent)
         self.bus.remove("detach_intent", self.handle_detach_intent)
         self.bus.remove("detach_skill", self.handle_detach_skill)
+        self.bus.remove(str(SpecMessage.INTENT_REGISTER_KEYWORD), self.handle_register_keyword_intent)
+        self.bus.remove(str(SpecMessage.ENTITY_REGISTER), self.handle_register_entity)
+        self.bus.remove(str(SpecMessage.INTENT_DEREGISTER), self.handle_intent_deregister)
+        self.bus.remove(str(SpecMessage.ENTITY_DEREGISTER), self.handle_entity_deregister)
+        self.bus.remove(str(SpecMessage.SKILL_DEREGISTER), self.handle_skill_deregister)
+        self.bus.remove(str(SpecMessage.INTENT_ENABLE), self.handle_intent_enable)
+        self.bus.remove(str(SpecMessage.INTENT_DISABLE), self.handle_intent_disable)
         self.bus.remove("intent.service.palavreado.get", self.handle_get_palavreado)
         self.bus.remove("intent.service.palavreado.manifest.get", self.handle_palavreado_manifest)
         self.bus.remove("intent.service.palavreado.vocab.manifest.get", self.handle_vocab_manifest)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = ["simplematch", "quebra_frases"]
 
 [project.optional-dependencies]
 ovos = [
-    "ovos-bus-client>=2.4.0a1",
+    "ovos-bus-client>=2.5.1a1,<3.0.0",
     "ovos-config",
     # opm.pipeline entrypoints + the bus-client 2.x stack need modern
     # opm/workshop; bare floors backtrack to ancient releases that break
@@ -41,7 +41,7 @@ ovos = [
 dev = [
     "pytest",
     "pytest-cov",
-    "ovos-bus-client>=2.4.0a1",
+    "ovos-bus-client>=2.5.1a1,<3.0.0",
     "ovos-config",
     "ovos-plugin-manager>=2.3.0a1,<3.0.0",
     "ovos-utils",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,16 +22,19 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = ["simplematch", "quebra_frases"]
 
 [project.optional-dependencies]
 ovos = [
     "ovos-bus-client>=2.4.0a1",
     "ovos-config",
-    "ovos-plugin-manager",
+    # opm.pipeline entrypoints + the bus-client 2.x stack need modern
+    # opm/workshop; bare floors backtrack to ancient releases that break
+    # collection (mycroft_bus_client / get_mycroft_bus import skew).
+    "ovos-plugin-manager>=2.3.0a1,<3.0.0",
     "ovos-utils",
-    "ovos-workshop",
+    "ovos-workshop>=2.0.1a1",
     "ovos-spec-tools>=0.16.1a2",
     "langcodes",
 ]
@@ -40,9 +43,9 @@ dev = [
     "pytest-cov",
     "ovos-bus-client>=2.4.0a1",
     "ovos-config",
-    "ovos-plugin-manager",
+    "ovos-plugin-manager>=2.3.0a1,<3.0.0",
     "ovos-utils",
-    "ovos-workshop",
+    "ovos-workshop>=2.0.1a1",
     "ovos-spec-tools>=0.16.1a2",
     "langcodes",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ ovos = [
     "ovos-plugin-manager",
     "ovos-utils",
     "ovos-workshop",
-    "ovos-spec-tools>=0.10.0a1",
+    "ovos-spec-tools>=0.11.0a1",
     "langcodes",
 ]
 dev = [
@@ -43,7 +43,7 @@ dev = [
     "ovos-plugin-manager",
     "ovos-utils",
     "ovos-workshop",
-    "ovos-spec-tools>=0.10.0a1",
+    "ovos-spec-tools>=0.11.0a1",
     "langcodes",
 ]
 test = ["palavreado[dev]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,23 +27,23 @@ dependencies = ["simplematch", "quebra_frases"]
 
 [project.optional-dependencies]
 ovos = [
-    "ovos-bus-client",
+    "ovos-bus-client>=2.4.0a1",
     "ovos-config",
     "ovos-plugin-manager",
     "ovos-utils",
     "ovos-workshop",
-    "ovos-spec-tools>=0.11.0a1",
+    "ovos-spec-tools>=0.16.1a2",
     "langcodes",
 ]
 dev = [
     "pytest",
     "pytest-cov",
-    "ovos-bus-client",
+    "ovos-bus-client>=2.4.0a1",
     "ovos-config",
     "ovos-plugin-manager",
     "ovos-utils",
     "ovos-workshop",
-    "ovos-spec-tools>=0.11.0a1",
+    "ovos-spec-tools>=0.16.1a2",
     "langcodes",
 ]
 test = ["palavreado[dev]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ ovos = [
     "ovos-plugin-manager",
     "ovos-utils",
     "ovos-workshop",
+    "ovos-spec-tools>=0.10.0a1",
     "langcodes",
 ]
 dev = [
@@ -42,6 +43,7 @@ dev = [
     "ovos-plugin-manager",
     "ovos-utils",
     "ovos-workshop",
+    "ovos-spec-tools>=0.10.0a1",
     "langcodes",
 ]
 test = ["palavreado[dev]"]

--- a/test/end2end/test_intent4_consume_e2e.py
+++ b/test/end2end/test_intent4_consume_e2e.py
@@ -1,0 +1,194 @@
+"""OVOS-INTENT-4 *consumer* end-to-end tests for the Palavreado pipeline.
+
+``test/test_ovoscope_e2e.py`` proves palavreado matches intents registered via
+the legacy ``register_vocab`` / ``register_intent`` events. This suite proves
+palavreado *consumes the INTENT-4 spec registration topics* (``ovos-intent-4.md``)
+and then matches.
+
+Palavreado is a **keyword** engine: it consumes ``ovos.intent.register.keyword``
+(§5) and not ``ovos.intent.register.template`` (§11). Each test boots a real
+``MiniCroft`` pinned to the palavreado pipeline, emits the spec registration on
+the wire, sends a matching utterance, and asserts the intent dispatches
+``<skill_id>:<intent_name>`` — proving spec-topic consumption.
+"""
+import time
+import unittest
+
+import pytest
+
+ovoscope = pytest.importorskip(
+    "ovoscope", reason="ovoscope not installed; skipping E2E tests"
+)
+
+from ovoscope import E2EPipelineHarness  # noqa: E402
+from ovos_bus_client.message import Message  # noqa: E402
+from ovos_spec_tools import SpecMessage  # noqa: E402
+
+from palavreado.opm import PalavreadoPipeline  # noqa: E402
+
+PIPELINE_ID = "palavreado"
+CONFIG_KEY = "palavreado"
+
+REGISTER_KEYWORD = str(SpecMessage.INTENT_REGISTER_KEYWORD)
+REGISTER_TEMPLATE = str(SpecMessage.INTENT_REGISTER_TEMPLATE)
+INTENT_DEREGISTER = str(SpecMessage.INTENT_DEREGISTER)
+SKILL_DEREGISTER = str(SpecMessage.SKILL_DEREGISTER)
+INTENT_DISABLE = str(SpecMessage.INTENT_DISABLE)
+INTENT_ENABLE = str(SpecMessage.INTENT_ENABLE)
+
+
+class _Intent4PalavreadoHarness(E2EPipelineHarness):
+    PIPELINE_ID = PIPELINE_ID
+    CONFIG_KEY = CONFIG_KEY
+    PLUGIN_CONFIG = {}
+    SKILL_ID = "intent4_palavreado.skill"
+
+    pipeline: PalavreadoPipeline  # type: ignore[assignment]
+
+    def _register_keyword(self, intent_name, required, *, optional=None,
+                          one_of=None, excluded=None, lang="en-US", settle=0.6):
+        def _descs(d):
+            return [{"name": n, "samples": s} for n, s in (d or {}).items()]
+
+        payload = {
+            "skill_id": self.SKILL_ID,
+            "intent_name": intent_name,
+            "lang": lang,
+            "required": _descs(required),
+            "optional": _descs(optional),
+            "one_of": [_descs(g) for g in (one_of or [])],
+            "excluded": _descs(excluded),
+        }
+        self.bus.emit(Message(REGISTER_KEYWORD, payload,
+                              {"skill_id": self.SKILL_ID}))
+        time.sleep(settle)
+
+    def _emit(self, topic, intent_name=None, settle=0.6, **extra):
+        data = {"skill_id": self.SKILL_ID, "lang": "en-US"}
+        if intent_name is not None:
+            data["intent_name"] = intent_name
+        data.update(extra)
+        self.bus.emit(Message(topic, data, {"skill_id": self.SKILL_ID}))
+        time.sleep(settle)
+
+
+class TestSpecKeywordConsumed(_Intent4PalavreadoHarness):
+    """§5: a keyword intent registered on the spec topic becomes matchable."""
+
+    def test_spec_keyword_registration_is_matchable(self):
+        self._register_keyword(
+            "lights_off",
+            required={"TurnOff": ["off", "disable", "shutdown"],
+                      "Light": ["light", "lights", "lamp"]},
+        )
+        msg = self.send_and_capture(
+            "turn off the lights",
+            expected_types=[f"{self.SKILL_ID}:lights_off"],
+        )
+        self.assertIsNotNone(msg, "expected intent match from spec registration")
+        self.assertEqual(msg.msg_type, f"{self.SKILL_ID}:lights_off")
+
+    def test_spec_excluded_suppresses_match(self):
+        """An ``excluded`` keyword blocks the match (§5.4)."""
+        self._register_keyword(
+            "lights_off",
+            required={"TurnOff": ["off"], "Light": ["lights"]},
+            excluded={"Question": ["what", "how"]},
+        )
+        self.expect_no_match("what turns off the lights", timeout=3.0)
+
+
+class TestLegacyStillConsumed(_Intent4PalavreadoHarness):
+    """Back-compat: legacy vocab/intent registration still matches."""
+
+    def test_legacy_keyword_registration_still_matches(self):
+        from ovoscope import register_adapt_intent, register_adapt_vocab
+        from ovos_workshop.intents import IntentBuilder
+
+        register_adapt_vocab(self.bus, f"{self.SKILL_ID}:TurnOff", ["off"])
+        register_adapt_vocab(self.bus, f"{self.SKILL_ID}:Light", ["lights"])
+        register_adapt_intent(
+            self.bus,
+            IntentBuilder(f"{self.SKILL_ID}:lights_off")
+            .require(f"{self.SKILL_ID}:TurnOff")
+            .require(f"{self.SKILL_ID}:Light"),
+        )
+        time.sleep(0.4)
+        msg = self.send_and_capture(
+            "turn off the lights",
+            expected_types=[f"{self.SKILL_ID}:lights_off"],
+        )
+        self.assertIsNotNone(msg, "legacy registration must still match")
+
+
+class TestSpecDeregister(_Intent4PalavreadoHarness):
+    """§8.2 / §8.4: spec deregistration removes a spec-registered intent."""
+
+    def test_spec_deregister_removes_intent(self):
+        self._register_keyword(
+            "lights_off",
+            required={"TurnOff": ["off"], "Light": ["lights"]},
+        )
+        self.assertIsNotNone(
+            self.send_and_capture("turn off the lights",
+                                  expected_types=[f"{self.SKILL_ID}:lights_off"]),
+            "sanity: intent should match before deregister",
+        )
+        self._emit(INTENT_DEREGISTER, "lights_off")
+        self.expect_no_match("turn off the lights", timeout=3.0)
+
+    def test_spec_skill_deregister_removes_intent(self):
+        self._register_keyword(
+            "lights_off",
+            required={"TurnOff": ["off"], "Light": ["lights"]},
+        )
+        self._emit(SKILL_DEREGISTER)
+        self.expect_no_match("turn off the lights", timeout=3.0)
+
+
+class TestSpecDisableEnable(_Intent4PalavreadoHarness):
+    """§8.5: ``ovos.intent.disable`` suppresses, ``ovos.intent.enable`` re-arms.
+
+    Palavreado keeps a global ``_disabled_intents`` set keyed on the
+    registration (``match`` filters disabled names out), so disable is
+    registration-scoped per §8.5 and observable regardless of session.
+    """
+
+    def test_spec_disable_suppresses_intent(self):
+        self._register_keyword(
+            "lights_off",
+            required={"TurnOff": ["off"], "Light": ["lights"]},
+        )
+        self._emit(INTENT_DISABLE, "lights_off")
+        self.expect_no_match("turn off the lights", timeout=3.0)
+
+    def test_spec_enable_rearms_intent(self):
+        self._register_keyword(
+            "lights_off",
+            required={"TurnOff": ["off"], "Light": ["lights"]},
+        )
+        self._emit(INTENT_DISABLE, "lights_off")
+        self._emit(INTENT_ENABLE, "lights_off")
+        msg = self.send_and_capture(
+            "turn off the lights",
+            expected_types=[f"{self.SKILL_ID}:lights_off"],
+        )
+        self.assertIsNotNone(msg, "intent should match again after enable")
+
+
+class TestNegativeTemplateTopic(_Intent4PalavreadoHarness):
+    """§11: a keyword engine MUST NOT consume the *template* topic."""
+
+    def test_template_topic_does_not_match_on_keyword_engine(self):
+        self.bus.emit(Message(REGISTER_TEMPLATE, {
+            "skill_id": self.SKILL_ID,
+            "intent_name": "play_music",
+            "lang": "en-US",
+            "samples": ["play {query}", "put on {query}"],
+        }, {"skill_id": self.SKILL_ID}))
+        time.sleep(0.5)
+        self.expect_no_match("play the beatles", timeout=3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_opm.py
+++ b/test/test_opm.py
@@ -193,5 +193,163 @@ class TestPalavreadoPipelineOptional(unittest.TestCase):
         self.assertGreaterEqual(r_with.match_data["conf"], r_without.match_data["conf"])
 
 
+class TestPalavreadoIntent4(unittest.TestCase):
+    """OVOS-INTENT-4 keyword registration consumed alongside legacy topics."""
+
+    def setUp(self):
+        from ovos_spec_tools import SpecMessage
+        self.SpecMessage = SpecMessage
+        self.bus = mock.Mock()
+        self.pipeline = PalavreadoPipeline(bus=self.bus, config={})
+
+    def _register_lights(self):
+        # OVOS-INTENT-4 §5.2 keyword payload, all four roles present
+        msg = Message(str(self.SpecMessage.INTENT_REGISTER_KEYWORD), {
+            "skill_id": "lighting.skill",
+            "intent_name": "set_brightness",
+            "lang": "en-US",
+            "required": [
+                {"name": "set", "samples": ["set", "change", "adjust"]},
+                {"name": "brightness", "samples": ["brightness", "light level"]},
+            ],
+            "optional": [],
+            "one_of": [
+                [
+                    {"name": "up", "samples": ["up", "higher", "brighter"]},
+                    {"name": "down", "samples": ["down", "lower", "dimmer"]},
+                ]
+            ],
+            "excluded": [
+                {"name": "question", "samples": ["what is", "how"]},
+            ],
+        }, context={"skill_id": "lighting.skill"})
+        self.pipeline.handle_register_keyword_intent(msg)
+
+    def test_register_keyword_intent_and_match(self):
+        self._register_lights()
+        msg = Message("recognizer_loop:utterance",
+                      {"utterances": ["set brightness higher"], "lang": "en-US"})
+        result = self.pipeline.match_low(["set brightness higher"], "en-US", msg)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_type, "lighting.skill:set_brightness")
+        self.assertEqual(result.skill_id, "lighting.skill")
+
+    def test_excluded_suppresses_match(self):
+        self._register_lights()
+        msg = Message("recognizer_loop:utterance",
+                      {"utterances": ["what is the brightness"], "lang": "en-US"})
+        result = self.pipeline.match_low(["what is the brightness"], "en-US", msg)
+        self.assertIsNone(result)
+
+    def test_missing_role_key_rejected(self):
+        msg = Message(str(self.SpecMessage.INTENT_REGISTER_KEYWORD), {
+            "skill_id": "skill.x", "intent_name": "bad", "lang": "en-US",
+            "required": [{"name": "kw", "samples": ["foo"]}],
+            # missing optional / one_of / excluded
+        })
+        self.pipeline.handle_register_keyword_intent(msg)
+        names = [i["name"] for i in self.pipeline._registered_intents]
+        self.assertNotIn("skill.x:bad", names)
+
+    def test_required_and_one_of_empty_rejected(self):
+        msg = Message(str(self.SpecMessage.INTENT_REGISTER_KEYWORD), {
+            "skill_id": "skill.x", "intent_name": "empty", "lang": "en-US",
+            "required": [], "optional": [{"name": "o", "samples": ["x"]}],
+            "one_of": [], "excluded": [],
+        })
+        self.pipeline.handle_register_keyword_intent(msg)
+        names = [i["name"] for i in self.pipeline._registered_intents]
+        self.assertNotIn("skill.x:empty", names)
+
+    def test_empty_samples_rejected(self):
+        msg = Message(str(self.SpecMessage.INTENT_REGISTER_KEYWORD), {
+            "skill_id": "skill.x", "intent_name": "nosamples", "lang": "en-US",
+            "required": [{"name": "kw", "samples": []}],
+            "optional": [], "one_of": [], "excluded": [],
+        })
+        self.pipeline.handle_register_keyword_intent(msg)
+        names = [i["name"] for i in self.pipeline._registered_intents]
+        self.assertNotIn("skill.x:nosamples", names)
+
+    def test_duplicate_role_rejected(self):
+        msg = Message(str(self.SpecMessage.INTENT_REGISTER_KEYWORD), {
+            "skill_id": "skill.x", "intent_name": "dup", "lang": "en-US",
+            "required": [{"name": "kw", "samples": ["a"]}],
+            "optional": [{"name": "kw", "samples": ["b"]}],
+            "one_of": [], "excluded": [],
+        })
+        self.pipeline.handle_register_keyword_intent(msg)
+        names = [i["name"] for i in self.pipeline._registered_intents]
+        self.assertNotIn("skill.x:dup", names)
+
+    def test_disable_then_enable(self):
+        self._register_lights()
+        utt = ["set brightness higher"]
+        msg = Message("recognizer_loop:utterance", {"utterances": utt, "lang": "en-US"})
+
+        self.pipeline.handle_intent_disable(Message(
+            str(self.SpecMessage.INTENT_DISABLE),
+            {"skill_id": "lighting.skill", "intent_name": "set_brightness"}))
+        self.assertIsNone(self.pipeline.match_low(utt, "en-US", msg))
+
+        self.pipeline.handle_intent_enable(Message(
+            str(self.SpecMessage.INTENT_ENABLE),
+            {"skill_id": "lighting.skill", "intent_name": "set_brightness"}))
+        self.assertIsNotNone(self.pipeline.match_low(utt, "en-US", msg))
+
+    def test_deregister_removes_intent(self):
+        self._register_lights()
+        self.pipeline.handle_intent_deregister(Message(
+            str(self.SpecMessage.INTENT_DEREGISTER),
+            {"skill_id": "lighting.skill", "intent_name": "set_brightness"}))
+        msg = Message("recognizer_loop:utterance",
+                      {"utterances": ["set brightness higher"], "lang": "en-US"})
+        self.assertIsNone(self.pipeline.match_low(["set brightness higher"], "en-US", msg))
+
+    def test_skill_deregister_removes_all(self):
+        self._register_lights()
+        self.pipeline.handle_skill_deregister(Message(
+            str(self.SpecMessage.SKILL_DEREGISTER), {"skill_id": "lighting.skill"}))
+        msg = Message("recognizer_loop:utterance",
+                      {"utterances": ["set brightness higher"], "lang": "en-US"})
+        self.assertIsNone(self.pipeline.match_low(["set brightness higher"], "en-US", msg))
+        self.assertEqual(self.pipeline._registered_intents, [])
+
+    def test_register_entity_stored(self):
+        self.pipeline.handle_register_entity(Message(
+            str(self.SpecMessage.ENTITY_REGISTER), {
+                "skill_id": "music.skill", "entity_name": "engine", "lang": "en-US",
+                "samples": ["spotify", "youtube music"],
+            }))
+        self.assertIn("spotify", self.pipeline._vocab["en-US"]["engine"])
+
+    def test_register_entity_empty_samples_rejected(self):
+        self.pipeline.handle_register_entity(Message(
+            str(self.SpecMessage.ENTITY_REGISTER), {
+                "skill_id": "music.skill", "entity_name": "engine", "lang": "en-US",
+                "samples": [],
+            }))
+        self.assertNotIn("engine", self.pipeline._vocab["en-US"])
+
+    def test_re_registration_replaces(self):
+        self._register_lights()
+        # re-register with different required vocab — must replace, not raise
+        self._register_lights()
+        count = len([i for i in self.pipeline._registered_intents
+                     if i["name"] == "lighting.skill:set_brightness"])
+        self.assertEqual(count, 1)
+
+    def test_legacy_topics_still_work(self):
+        # back-compat: legacy register_vocab + register_intent path unaffected
+        from ovos_workshop.intents import IntentBuilder
+        self.pipeline.handle_register_vocab(_vocab_msg("Hi", "hello"))
+        builder = IntentBuilder("legacy:HiIntent").require("Hi")
+        self.pipeline.handle_register_intent(_intent_msg(builder))
+        msg = Message("recognizer_loop:utterance", {"utterances": ["hello"], "lang": "en-US"})
+        result = self.pipeline.match_high(["hello"], "en-US", msg)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_type, "legacy:HiIntent")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adopts the **OVOS-INTENT-4** intent/entity registration bus contract in the palavreado pipeline plugin, **in addition to** the existing legacy `register_vocab` / `register_intent` / `detach_*` handlers (back-compat preserved).

palavreado is keyword/slot based, so the primary topic is **`ovos.intent.register.keyword`** (spec §5).

## Bus topics now consumed (from `ovos_spec_tools.SpecMessage`)

| Topic | Handler | Spec |
|-------|---------|------|
| `ovos.intent.register.keyword` | `handle_register_keyword_intent` | §5 |
| `ovos.entity.register` | `handle_register_entity` | §7 |
| `ovos.intent.deregister` | `handle_intent_deregister` | §8.2 |
| `ovos.entity.deregister` | `handle_entity_deregister` | §8.3 |
| `ovos.skill.deregister` | `handle_skill_deregister` | §8.4 |
| `ovos.intent.enable` / `ovos.intent.disable` | `handle_intent_enable` / `handle_intent_disable` | §8.5 |

## Spec → palavreado mapping (§5 keyword payload)

- `required[]` descriptor → `IntentCreator.require(name, samples)`
- `optional[]` descriptor → `IntentCreator.optionally(name, samples)`
- `one_of[]` group member → `IntentCreator.optionally(...)` (palavreado has no native "at least one of" slot; mirrors the legacy `at_least_one` handling)
- `excluded[]` descriptor → `IntentContainer.exclude_keywords(...)` (§5.4 suppression)
- inline `samples` → fed straight into the slot (no `.voc` file path on the wire, §5.1)
- entity `samples` (§7) → per-lang vocab store keyed by `entity_name` (value-set hint, never a precondition)

Internal intent name is `<skill_id>:<intent_name>` so `skill_id` is recoverable via `name.split(":")[0]`, matching the existing adapt-envelope convention.

## Validation (malformed-payload rules)

Per §5.3 / §7.2, registrations are rejected and logged at WARN (the only producer signal on a fire-and-forget bus) when: a role key is missing; `required` and `one_of` are both empty; a descriptor has no non-empty `samples`; or a vocabulary `name` appears under more than one role. Empty-samples entity registrations are rejected per §7.2.

Re-registration replaces the existing intent per `(skill_id, intent_name, lang)` (§8.1). Disabled intents (§8.5) are excluded from match candidacy in `_match_intent`.

## Tests

Added `TestPalavreadoIntent4` to `test/test_opm.py` (12 cases): register-via-`ovos.intent.register.keyword` + match, `excluded` suppression, malformed-payload rejection (missing role / empty required+one_of / empty samples / duplicate role), disable→enable, deregister, skill-deregister, entity registration + rejection, replacement, and a back-compat check that legacy topics still match.

`test/test_opm.py`: **32 passed**. Full unit suite: **105 passed**. (The 11 `test_ovoscope_e2e.py` errors are pre-existing and environment-only — palavreado is not pip-installed as an opm entry point in the harness venv, plus a missing libfann for padatious; confirmed present on a clean tree.)

## Dependency

`ovos-spec-tools>=0.10.0a1` added to the `ovos` and `dev` extras (prerelease floor pin; no `--pre`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)