### PR TITLE
feat: OVOS-CONTEXT-1 §7 pre-match context injection (keyword engine)

### DIFF
--- a/palavreado/__init__.py
+++ b/palavreado/__init__.py
@@ -250,7 +250,9 @@ class IntentContainer:
 
     # ── matching ────────────────────────────────────────────────────────────
 
-    def calc_intents(self, query: str) -> Iterator[dict]:
+    def calc_intents(self, query: str,
+                     context_candidates: Dict[str, Dict[str, str]] = None
+                     ) -> Iterator[dict]:
         """Yield scored match results for every intent that matches *query*.
 
         Only intents with confidence > 0 are yielded.  Each result is a dict
@@ -259,6 +261,12 @@ class IntentContainer:
 
         Args:
             query: The utterance to match against all registered intents.
+            context_candidates: OVOS-CONTEXT-1 §7 pre-match injection map,
+                ``{intent_name: {keyword_name: value}}``.  A keyword the
+                utterance does not fill is filled from its candidate value
+                (a live context entry of the same name), letting an intent
+                requiring that keyword match without the utterance carrying it.
+                An utterance-matched keyword always wins over its candidate.
 
         Yields:
             Match result dicts ordered by registration, not by confidence.
@@ -322,6 +330,9 @@ class IntentContainer:
             if intent_name in excluded or not intent["required"]:
                 continue
 
+            # OVOS-CONTEXT-1 §7 candidate values for this intent's keywords.
+            injected = (context_candidates or {}).get(intent_name, {})
+
             n_req = len(intent["required"])
             n_opt = len(intent["optional"])
             partial_conf = 1.0 / n_req
@@ -362,20 +373,26 @@ class IntentContainer:
             for kw_dict, weight in ((intent["required"], partial_conf),
                                     (intent["optional"], partial_opt_conf)):
                 for kw, kw_samples in kw_dict.items():
-                    if not kw_samples:
-                        continue
-                    if query in kw_samples:
-                        matches[kw] = [query]
+                    if kw_samples and kw not in matches:
+                        if query in kw_samples:
+                            matches[kw] = [query]
+                            conf += weight
+                            remainder = ""
+                        else:
+                            kws, quality = _match(kw_samples)
+                            if kws:
+                                matches[kw] = kws
+                                conf += weight * quality
+                                remainder = get_utterance_remainder(remainder, kws)
+                                if remainder in kws:
+                                    remainder = ""
+                    # OVOS-CONTEXT-1 §7: fill an unmatched keyword from its live
+                    # context candidate.  Only when the utterance itself did not
+                    # produce it, so an utterance-matched value always wins; the
+                    # value is context-supplied and so leaves the remainder as-is.
+                    if kw not in matches and kw in injected:
+                        matches[kw] = [injected[kw]]
                         conf += weight
-                        remainder = ""
-                    else:
-                        kws, quality = _match(kw_samples)
-                        if kws:
-                            matches[kw] = kws
-                            conf += weight * quality
-                            remainder = get_utterance_remainder(remainder, kws)
-                            if remainder in kws:
-                                remainder = ""
 
             # All required slots must be present in matches.
             if not intent["required"].keys() <= matches.keys():
@@ -395,11 +412,15 @@ class IntentContainer:
                     "_rw": _rw,
                 }
 
-    def calc_intent(self, query: str) -> dict:
+    def calc_intent(self, query: str,
+                    context_candidates: Dict[str, Dict[str, str]] = None
+                    ) -> dict:
         """Return the single best-matching intent result for *query*.
 
         Args:
             query: The utterance to match.
+            context_candidates: OVOS-CONTEXT-1 §7 pre-match injection map
+                (see :meth:`calc_intents`).
 
         Returns:
             The highest-confidence match dict (keys: ``name``, ``conf``,
@@ -410,7 +431,7 @@ class IntentContainer:
         best = None
         best_conf = -1.0
         best_matched = -1
-        for result in self.calc_intents(query):
+        for result in self.calc_intents(query, context_candidates):
             c = result["conf"]
             mw = result["_mw"]
             rem = result["_rw"]

--- a/palavreado/opm.py
+++ b/palavreado/opm.py
@@ -1,5 +1,6 @@
 """OVOS pipeline plugin wrapping palavreado — keyword intent matching (adapt replacement)."""
 
+import time
 from typing import Dict, List, Optional, Union
 
 from langcodes import closest_match
@@ -13,7 +14,7 @@ from ovos_utils import flatten_list
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.log import LOG
-from ovos_spec_tools import SpecMessage, gate_satisfied
+from ovos_spec_tools import SpecMessage, gate_satisfied, is_live
 from ovos_workshop.intents import open_intent_envelope
 
 from palavreado import IntentContainer
@@ -66,6 +67,13 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
         # {"requires": [...], "excludes": [...]}.  Enforced at match time via
         # ovos_spec_tools.gate_satisfied (separate/additive to excluded_keywords).
         self._context_gates: Dict[str, dict] = {}
+
+        # OVOS-CONTEXT-1 §7 injection index, keyed by internal intent name →
+        # the intent's declared keyword names (required + optional + one_of).
+        # A live context entry named for one of these keywords is injected as a
+        # candidate keyword value before matching.  Kept in step with the
+        # container's intents through the same register/detach paths.
+        self._intent_keywords: Dict[str, List[str]] = {}
 
         # ── legacy registration topics (back-compat) ──────────────────────────
         self.bus.on("register_vocab", self.handle_register_vocab)
@@ -174,6 +182,12 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
         gate = self._context_gate(message.data)
         if gate is not None:
             self._context_gates[intent.name] = gate
+
+        # OVOS-CONTEXT-1 §7 — index declared keywords for candidate injection.
+        keywords = [kw for kw, _ in (intent.requires or [])]
+        keywords += [kw for kw, _ in (intent.optional or [])]
+        keywords += [kw for group in (intent.at_least_one or []) for kw in group]
+        self._intent_keywords[intent.name] = keywords
 
         self._registered_intents.append(intent.__dict__)
 
@@ -310,6 +324,7 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
         self._registered_intents = [i for i in self._registered_intents
                                     if i.get("name") != internal_name]
         self._context_gates.pop(internal_name, None)
+        self._intent_keywords.pop(internal_name, None)
 
         # OVOS-CONTEXT-1: store optional context gating for this intent
         gate = self._context_gate(data)
@@ -333,6 +348,14 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
             excluded_samples += self._descriptor_samples(descriptor)
         if excluded_samples:
             container.exclude_keywords(internal_name, excluded_samples)
+
+        # OVOS-CONTEXT-1 §7 — index this intent's keyword names (the bare
+        # vocabulary names) so a context entry of the same name injects a
+        # candidate for the intent's keyword.
+        keyword_names = [d["name"] for d in required]
+        keyword_names += [d["name"] for d in optional]
+        keyword_names += [d["name"] for group in one_of for d in (group or [])]
+        self._intent_keywords[internal_name] = keyword_names
 
         self._registered_intents.append({"name": internal_name,
                                          "skill_id": skill_id,
@@ -396,6 +419,7 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
         internal_name = self._spec_intent_name(skill_id, intent_name)
         self._disabled_intents.discard(internal_name)
         self._context_gates.pop(internal_name, None)
+        self._intent_keywords.pop(internal_name, None)
         self._registered_intents = [i for i in self._registered_intents
                                     if i.get("name") != internal_name]
         for container in self.containers.values():
@@ -423,6 +447,8 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
                                   if not n.startswith(prefix)}
         self._context_gates = {n: g for n, g in self._context_gates.items()
                                if not n.startswith(prefix)}
+        self._intent_keywords = {n: k for n, k in self._intent_keywords.items()
+                                 if not n.startswith(prefix)}
         self._registered_intents = [i for i in self._registered_intents
                                     if i.get("skill_id") != skill_id
                                     and not i.get("name", "").startswith(prefix)]
@@ -457,6 +483,7 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
         if not intent_name:
             return
         self._context_gates.pop(intent_name, None)
+        self._intent_keywords.pop(intent_name, None)
         self._registered_intents = [i for i in self._registered_intents
                                      if i.get("name") != intent_name]
         for container in self.containers.values():
@@ -467,6 +494,8 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
         skill_id = message.data.get("skill_id", "")
         self._context_gates = {n: g for n, g in self._context_gates.items()
                                if not n.startswith(skill_id)}
+        self._intent_keywords = {n: k for n, k in self._intent_keywords.items()
+                                 if not n.startswith(skill_id)}
         self._registered_intents = [i for i in self._registered_intents
                                      if not i.get("name", "").startswith(skill_id)]
         self.registered_vocab = [v for v in self.registered_vocab
@@ -546,6 +575,51 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
         return gate_satisfied(intent_context, gate.get("requires"),
                               gate.get("excludes"), owner_id=owner_id)
 
+    @staticmethod
+    def _live_context_value(entries: Dict, name: str, skill_id: str,
+                            now: float) -> Optional[str]:
+        """Resolve a live non-null string context value for a keyword name.
+
+        Scope is read from the key (OVOS-CONTEXT-1 §3): the owner's private
+        entry ``<skill_id>:<name>`` is consulted first, then the shared bare
+        ``<name>``.  Flag entries (``value`` null / non-string) and dead
+        entries are ignored — those only gate, they never inject.
+        """
+        for key in (f"{skill_id}:{name}", name):
+            entry = entries.get(key)
+            if not isinstance(entry, dict):
+                continue
+            value = entry.get("value")
+            if not isinstance(value, str) or not value:
+                continue
+            if not is_live(entry, now):
+                continue
+            return value
+        return None
+
+    def _context_candidates(self, sess: Session) -> Dict[str, Dict[str, str]]:
+        """Build OVOS-CONTEXT-1 §7 pre-match candidates from ``intent_context``.
+
+        For every registered intent keyword that has a live non-null string
+        entry in ``session.intent_context`` (scope-resolved from the key using
+        the intent's ``skill_id``), emit ``{intent_name: {keyword: value}}``.
+        The matcher fills an otherwise-unmatched keyword from that value, so an
+        intent requiring the keyword matches without the utterance carrying it;
+        a value the utterance itself produces for the keyword wins over it.
+        """
+        entries = getattr(sess, "intent_context", None) or {}
+        if not entries or not self._intent_keywords:
+            return {}
+        now = time.time()
+        candidates: Dict[str, Dict[str, str]] = {}
+        for name, keywords in self._intent_keywords.items():
+            skill_id = name.split(":")[0]
+            for kw in keywords:
+                value = self._live_context_value(entries, kw, skill_id, now)
+                if value is not None:
+                    candidates.setdefault(name, {})[kw] = value
+        return candidates
+
     def _match_intent(self, utterances: tuple, lang: Optional[str] = None,
                       message: Optional[str] = None) -> Optional[IntentHandlerMatch]:
         """Match utterances against registered intents, honouring session blacklists.
@@ -572,11 +646,14 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
             return None
 
         container = self.containers[lang]
+        # OVOS-CONTEXT-1 §7 pre-match candidates, scope-resolved per intent.
+        context_candidates = self._context_candidates(sess)
         best = None
         best_conf = -1.0
 
         for utt in utts:
-            result = _calc_palavreado_intent(utt, container, sess)
+            result = _calc_palavreado_intent(utt, container, sess,
+                                             context_candidates)
             if result and result["name"] in self._disabled_intents:
                 continue  # OVOS-INTENT-4 §8.5: disabled intents are not candidates
             if result and not self._context_gate_ok(result["name"], sess):
@@ -629,14 +706,19 @@ class PalavreadoPipeline(ConfidenceMatcherPipeline):
 
 def _calc_palavreado_intent(utt: str,
                              container: IntentContainer,
-                             sess: Session) -> Optional[dict]:
+                             sess: Session,
+                             context_candidates: Optional[Dict[str, Dict[str, str]]] = None
+                             ) -> Optional[dict]:
     """Match *utt* against *container*, honouring session blacklists.
+
+    *context_candidates* carries the OVOS-CONTEXT-1 §7 pre-match injection map
+    (``{intent_name: {keyword: value}}``) forwarded to the matcher.
 
     Returns the raw result dict from :meth:`IntentContainer.calc_intent`,
     or ``None`` if nothing matched or the match is blacklisted.
     """
     try:
-        result = container.calc_intent(utt)
+        result = container.calc_intent(utt, context_candidates)
         if not result.get("name"):
             return None
         if result["name"] in (sess.blacklisted_intents or []):

--- a/test/test_opm.py
+++ b/test/test_opm.py
@@ -351,6 +351,96 @@ class TestPalavreadoIntent4(unittest.TestCase):
         self.assertEqual(result.match_type, "legacy:HiIntent")
 
 
+class TestPalavreadoContext1Injection(unittest.TestCase):
+    """OVOS-CONTEXT-1 §7 pre-match context injection for the keyword engine.
+
+    A live non-null string entry in ``session.intent_context`` is injected as a
+    candidate value for the intent keyword of the same name **before** matching,
+    so an intent requiring that keyword matches even when the utterance lacks it.
+    An utterance-provided value for the same keyword wins over the injected one;
+    a null-valued (flag) or dead entry is never injected -- it only gates.
+    """
+
+    SKILL_ID = "bio.skill"
+    INTENT = f"{SKILL_ID}:height_query"
+
+    def setUp(self):
+        from ovos_spec_tools import SpecMessage
+        self.SpecMessage = SpecMessage
+        self.bus = mock.Mock()
+        self.pipeline = PalavreadoPipeline(bus=self.bus, config={})
+        self._register(self.SKILL_ID)
+
+    def _register(self, skill_id):
+        # a keyword intent requiring a `tall_query` phrase and a `person`
+        # keyword; the utterance "how tall is he" never fills `person`.
+        data = {
+            "skill_id": skill_id,
+            "intent_name": "height_query",
+            "lang": "en-US",
+            "required": [
+                {"name": "tall_query", "samples": ["how tall is"]},
+                {"name": "person", "samples": ["bob", "alice"]},
+            ],
+            "optional": [],
+            "one_of": [],
+            "excluded": [],
+        }
+        self.pipeline.handle_register_keyword_intent(
+            Message(str(self.SpecMessage.INTENT_REGISTER_KEYWORD), data,
+                    context={"skill_id": skill_id}))
+
+    def _match(self, utterance, intent_context=None):
+        from ovos_bus_client.session import Session, SessionManager
+        sess = Session("ctx-session")
+        sess.intent_context = intent_context or {}
+        msg = Message("recognizer_loop:utterance",
+                      {"utterances": [utterance], "lang": "en-US"})
+        with mock.patch.object(SessionManager, "get", return_value=sess):
+            return self.pipeline.match_low([utterance], "en-US", msg)
+
+    def test_no_context_no_match(self):
+        """Without a live `person` entry the person keyword stays unfilled."""
+        self.assertIsNone(self._match("how tall is he"))
+
+    def test_shared_context_injected_as_keyword(self):
+        """A live shared {person: Bob} fills the person keyword and slot."""
+        ctx = {"person": {"value": "Bob"}}
+        result = self._match("how tall is he", intent_context=ctx)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_type, self.INTENT)
+        self.assertEqual(result.match_data["keywords"]["person"], ["Bob"])
+
+    def test_private_owner_context_injected(self):
+        """A live private <skill_id>:person entry fills the owner's keyword."""
+        ctx = {f"{self.SKILL_ID}:person": {"value": "Bob"}}
+        result = self._match("how tall is he", intent_context=ctx)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_data["keywords"]["person"], ["Bob"])
+
+    def test_private_other_skill_not_visible(self):
+        """A private entry owned by another skill is not injected here."""
+        ctx = {"other.skill:person": {"value": "Bob"}}
+        self.assertIsNone(self._match("how tall is he", intent_context=ctx))
+
+    def test_utterance_value_wins_over_context(self):
+        """A person value in the utterance beats the injected candidate."""
+        ctx = {"person": {"value": "Alice"}}
+        result = self._match("how tall is bob", intent_context=ctx)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_data["keywords"]["person"], ["bob"])
+
+    def test_flag_entry_not_injected(self):
+        """A null-valued (flag) entry gates only -- it is never injected."""
+        ctx = {"person": {"value": None}}
+        self.assertIsNone(self._match("how tall is he", intent_context=ctx))
+
+    def test_expired_entry_not_injected(self):
+        """A dead entry (turns_remaining<=0) is not injected."""
+        ctx = {"person": {"value": "Bob", "turns_remaining": 0}}
+        self.assertIsNone(self._match("how tall is he", intent_context=ctx))
+
+
 class TestPalavreadoContext1(unittest.TestCase):
     """OVOS-CONTEXT-1 requires_context / excludes_context gating at match time."""
 


### PR DESCRIPTION
Implements OVOS-CONTEXT-1 §7 pre-match **context injection** for the palavreado keyword engine, building on the already-merged §6 gating.

## What
palavreado is a keyword engine, so a string-valued context entry is identical to a matched keyword. At match time every **live non-null string** entry in `session.intent_context` (the canonical map, not any legacy store) is injected as a candidate value for the intent keyword of the same name **before** the container matches.

- **Scope from the key (§3):** a private `<skill_id>:<name>` entry is a candidate only for that skill's intents; a bare shared `<name>` is a candidate for any intent.
- **Existing keyword requirement consumes it:** an intent requiring keyword `person` matches "how tall is he" when `{person: Bob}` is live, **without** declaring `requires_context` — the keyword requirement is the declaration.
- **Utterance wins:** injection only fills a keyword the utterance did not produce, so an utterance-matched value always beats the injected candidate.
- **Flags stay gates:** null-valued (flag) and dead entries are never injected; the unchanged `requires_context`/`excludes_context` gating (via `gate_satisfied`) keeps handling those.

A per-intent keyword index (`_intent_keywords`) is built at registration from both the legacy envelope and the INTENT-4 keyword payload, and carried through the same detach/deregister paths. Candidates are built in `PalavreadoPipeline._context_candidates` (scope-resolved per intent using `ovos_spec_tools.is_live`) and injected in `IntentContainer.calc_intents` via a new `context_candidates` argument.

## Tests
New `TestPalavreadoContext1Injection` in `test/test_opm.py`: no-context→no-match; shared `{person: Bob}` injected as keyword + reported slot; private `<skill_id>:person`; private entry of another skill not visible; utterance value wins over context; flag entry only gates; dead entry not injected. Full suite green (119 passed; pre-existing ovoscope-fixture e2e errors are environment-specific and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)